### PR TITLE
issues: add 2 fixme problems

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -173,6 +173,11 @@ mod tests {
         let result = parse_num(&mut (&*input))?;
         assert_eq!(result, Num::Float(-123.456));
 
+        // FIXME: doesn't work it the digital starts with 0
+        let input = "123.0001";
+        let result = parse_num(&mut (&*input))?;
+        assert_eq!(result, Num::Float(123.0001));
+
         Ok(())
     }
 
@@ -233,6 +238,12 @@ mod tests {
                 JsonValue::Number(Num::Int(3)),
             ]),
         );
+        assert_eq!(result, expected);
+
+        // FIXME: doesn't work with empty object
+        let input = r#"{}"#;
+        let result = parse_object(&mut (&*input))?;
+        let expected = HashMap::new();
         assert_eq!(result, expected);
 
         Ok(())


### PR DESCRIPTION
发现代码有 2 处 bug，问题我会提交到这个月的答疑里。

1. 代码问题：JSON 解析空对象有问题
2. 代码问题：解析小数如果小数部分有前导0，解析结果不正确
3. 如果我想要要写出一个健壮的 json-parser （或者是开发其他的东西），在写出健壮的代码前，如何想出足够全面的测试用例呢？
4. 如果想消除当前 parser_number 里的 unwrap, 怎么写代码？
5. 如果解析失败，怎么能够像 js 的 json parse 一样给出类似 Uncaught SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
这样的提示，能够知道那个位置出错了，以及缺少哪个边界导致解析失败。